### PR TITLE
Handle WireGuard peer cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Virtual environment
+venv/
+
+# SQLite database
+management.db
+instance/
+ha_plugin/*.zip
+cloudflare.ini

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # HA-Management
-HomeAssistant central management
+
+A simple web based portal for managing multiple HomeAssistant systems. The application is written in Python using Flask with SQLite for storage. It offers a login system, a dashboard with a small status chart, pages to filter or inspect individual systems and a profile page to change credentials. More advanced remote management features can be added later.
+
+## Quick start
+
+Run the installer script on a fresh Ubuntu system to set up all dependencies, create a Python virtual environment and initialize the database. The script waits for any active apt or dpkg operations so you never need to remove lock files.  Add the `cleaninstall` argument to reinstall everything, reset the database and remove any existing WireGuard or Cloudflare configuration:
+
+```bash
+sudo bash install.sh [cleaninstall]
+```
+
+Afterwards activate the virtual environment and start the server:
+
+```bash
+source venv/bin/activate
+python run.py
+```
+
+Log in using the default credentials `admin` / `admin` and then change the password.
+
+Use the theme toggle in the navigation bar to switch between dark and light modes.
+
+The installer also sets up a basic WireGuard server configuration at `/etc/wireguard/wg0.conf`. Visit the "WireGuard" page after logging in to edit this configuration directly from the portal.
+
+The dashboard shows a small system monitor so you can keep an eye on CPU and memory usage of the server running the portal.
+
+### Organizations and plugin
+
+Create organizations from the "Organizations" page. Clients can be assigned to an organization and filtered by it on the clients overview.
+
+Add clients under an organization and download a plugin per client. Each client gets its own WireGuard key pair and IP address. Downloading the plugin again reuses the stored keys so no duplicate peers are added to `wg0.conf`.
+
+Use the **Settings** dropdown to reach pages for your profile, database backup, WireGuard and Cloudflare configuration. The **Backup** page lets you download the entire `management.db` database or upload a backup to restore from it. The Cloudflare page also allows you to start or stop the tunnel and configure the hostname, port and token.
+
+The included Home Assistant plugin now reports the hostname, CPU and memory usage of each system. It exposes an HTTP API that allows the portal to send remote reboot, shutdown or update commands, as well as run shell commands for advanced troubleshooting.
+Use the **Beheer Client** button to access these remote tools and a quick link to the Home Assistant web interface over the VPN connection.
+
+Install the plugin on your HA system by copying the `custom_components` folder and running the included `install.sh` script. The plugin connects via WireGuard and sends heartbeats every ten minutes by default.
+
+### Cloudflare tunnels
+
+The portal can manage two Cloudflare tunnels: one for the web interface and one for the VPN endpoint. The `install.sh` script installs `cloudflared` automatically. Use the Cloudflare settings page to configure both tunnels side by side and save them with a single click. Starting or stopping each tunnel remains a separate action. Running `start_tunnel.sh` manually still works if you prefer.
+
+#### Cloudflare setup guide
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), add your domain if you have not already done so.
+2. Navigate to **Zero Trust → Access → Tunnels** and create a new tunnel. Copy the generated **tunnel token**.
+3. Create two tunnels: one pointing to `ha-management.jayjaysrv.com` for the interface and one to `vpn-ha-management.jayjaysrv.com` for the VPN. In the portal's Cloudflare page enter each hostname, the local port that the web portal listens on (default `5000`) and paste the token.
+4. Click **Save** and then **Start** for each tunnel. The status should change to "active" in the Cloudflare dashboard within a few seconds.
+5. If you ever need to run a tunnel manually, execute `./start_tunnel.sh interface` or `./start_tunnel.sh vpn` from the project directory.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,29 @@
+from flask import Flask, redirect, url_for, request
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from .config import Config
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    login_manager.login_view = 'main.login'
+
+    @login_manager.unauthorized_handler
+    def unauthorized():
+        return redirect(url_for('main.login', next=request.path))
+
+    @app.errorhandler(401)
+    def handle_401(e):
+        return redirect(url_for('main.login', next=request.path))
+
+    from .views import main_bp
+    app.register_blueprint(main_bp)
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,10 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'change-me')
+    BASEDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    DB_PATH = os.path.join(BASEDIR, 'management.db')
+    SQLALCHEMY_DATABASE_URI = f'sqlite:///{DB_PATH}'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WG_CONFIG = '/etc/wireguard/wg0.conf'
+    CF_CONFIG = os.path.join(BASEDIR, 'cloudflare.ini')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,30 @@
+from . import db, login_manager
+from flask_login import UserMixin
+
+class Client(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    location = db.Column(db.String(100))
+    status = db.Column(db.String(50))
+    cpu = db.Column(db.Float)
+    memory = db.Column(db.Float)
+    ip_address = db.Column(db.String(20), unique=True)
+    wg_private_key = db.Column(db.Text)
+    wg_public_key = db.Column(db.Text)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organization.id'))
+
+class Organization(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    api_key = db.Column(db.String(64), unique=True)
+    clients = db.relationship('Client', backref='organization', lazy=True)
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(100), unique=True, nullable=False)
+    password = db.Column(db.String(200), nullable=False)
+    role = db.Column(db.String(50), default='admin')
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,25 @@
+body.dark {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(180deg, #2a2f3a, #000814);
+  color: #eee;
+  min-height: 100vh;
+}
+
+body.light {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(180deg, #fff, #d7e2f2);
+  color: #222;
+  min-height: 100vh;
+}
+
+.navbar {
+  background: #0d1117;
+}
+
+body.light .navbar {
+  background: #0d6efd;
+}
+
+.toggle-theme {
+  cursor: pointer;
+}

--- a/app/templates/backup.html
+++ b/app/templates/backup.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Backup Database</h2>
+<p>
+  <a class="btn btn-secondary" href="{{ url_for('main.backup', download=1) }}">Download backup</a>
+</p>
+<form method="post" enctype="multipart/form-data" style="max-width:400px;">
+  <div class="mb-3">
+    <input class="form-control" type="file" name="db" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Import</button>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>HA Management</title>
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+    <script>
+      function applyTheme() {
+        const theme = localStorage.getItem('theme') || 'dark';
+        document.body.className = theme;
+      }
+      function toggleTheme() {
+        const newTheme = document.body.className === 'dark' ? 'light' : 'dark';
+        document.body.className = newTheme;
+        localStorage.setItem('theme', newTheme);
+      }
+      document.addEventListener('DOMContentLoaded', applyTheme);
+    </script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container">
+    <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">HA Management</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto">
+        {% if current_user.is_authenticated %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.dashboard') }}">Dashboard</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.clients_list') }}">Clients</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.organizations') }}">Organizations</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+            Instellingen
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="{{ url_for('main.profile') }}">Profile</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('main.backup') }}">Backup</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('main.wireguard') }}">WireGuard</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('main.cloudflare') }}">Cloudflare</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><span class="dropdown-item toggle-theme" onclick="toggleTheme()">Toggle Theme</span></li>
+          </ul>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.logout') }}">Logout ({{ current_user.username }})</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for m in messages %}
+        <div class="alert alert-warning">{{ m }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/client.html
+++ b/app/templates/client.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <h3 class="card-title">{{ client.name }}</h3>
+    <p class="card-text">Status: {{ client.status or 'unknown' }}</p>
+    <p class="card-text">CPU: {{ client.cpu or 'n/a' }}% Mem: {{ client.memory or 'n/a' }}%</p>
+    <a class="btn btn-primary" href="{{ url_for('main.client_manage', client_id=client.id) }}">Beheer Client</a>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/client_add.html
+++ b/app/templates/client_add.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Add Client</h2>
+<form method="post" style="max-width:400px;">
+  <div class="mb-3">
+    <input class="form-control" name="name" placeholder="Client name" required>
+  </div>
+  <div class="mb-3">
+    <select class="form-select" name="organization_id" required>
+      {% for org in orgs %}
+      <option value="{{ org.id }}">{{ org.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/client_edit.html
+++ b/app/templates/client_edit.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Client</h2>
+<form method="post" style="max-width:400px;">
+  <div class="mb-3">
+    <input class="form-control" name="name" value="{{ client.name }}" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="location" value="{{ client.location or '' }}" placeholder="Location">
+  </div>
+  <div class="mb-3">
+    <select class="form-select" name="organization_id" required>
+      {% for org in orgs %}
+      <option value="{{ org.id }}" {% if client.organization_id == org.id %}selected{% endif %}>{{ org.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a class="btn btn-danger" href="{{ url_for('main.client_delete', client_id=client.id) }}">Delete</a>
+</form>
+{% endblock %}

--- a/app/templates/client_manage.html
+++ b/app/templates/client_manage.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ client.name }}</h2>
+<p>Status: {{ client.status or 'unknown' }}</p>
+<p>CPU: {{ client.cpu or 'n/a' }}% Mem: {{ client.memory or 'n/a' }}%</p>
+<div class="mb-3">
+  <a class="btn btn-info" href="{{ url_for('main.download_plugin', client_id=client.id) }}">Download Plugin</a>
+  <a class="btn btn-secondary" href="{{ url_for('main.client_action', client_id=client.id, cmd='update') }}">Update Plugin</a>
+  <a class="btn btn-danger" href="{{ url_for('main.client_action', client_id=client.id, cmd='reboot') }}">Reboot</a>
+  <a class="btn btn-secondary" href="{{ url_for('main.client_action', client_id=client.id, cmd='shutdown') }}">Shutdown</a>
+   {% if client.ip_address %}
+   <a class="btn btn-primary" href="http://{{ client.ip_address.split('/')[0] }}:8123" target="_blank">Open HA</a>
+   {% endif %}
+</div>
+<form method="post" class="mb-3">
+  <div class="mb-3">
+    <label class="form-label">Remote Shell</label>
+    <textarea class="form-control" name="cmd" rows="3" placeholder="Enter command"></textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Run Command</button>
+</form>
+{% if output %}
+<pre class="bg-dark text-light p-2">{{ output }}</pre>
+{% endif %}
+{% endblock %}

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2>Clients</h2>
+  <form method="get" class="d-flex" style="max-width:500px;">
+    <input class="form-control me-2" type="text" name="q" value="{{ q }}" placeholder="Filter">
+    <select class="form-select me-2" name="org">
+      <option value="">All orgs</option>
+      {% for org in orgs %}
+      <option value="{{ org.id }}" {% if org_id and org.id == org_id|int %}selected{% endif %}>{{ org.name }}</option>
+      {% endfor %}
+    </select>
+    <button class="btn btn-primary" type="submit">Search</button>
+  </form>
+  </form>
+  <a class="btn btn-primary ms-2" href="{{ url_for('main.client_add') }}">Add Client</a>
+  <a class="btn btn-secondary ms-2" href="{{ url_for('main.export_clients') }}">Export</a>
+</div>
+<div class="row">
+{% for client in clients %}
+  <div class="col-md-4 mb-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h5 class="card-title">{{ client.name }}</h5>
+        <p class="card-text">Status: {{ client.status or 'unknown' }}</p>
+        <p class="card-text">CPU: {{ client.cpu or 'n/a' }}% Mem: {{ client.memory or 'n/a' }}%</p>
+        <a class="btn btn-sm btn-secondary" href="{{ url_for('main.client_manage', client_id=client.id) }}">Manage</a>
+        <a class="btn btn-sm btn-info" href="{{ url_for('main.download_plugin', client_id=client.id) }}">Plugin</a>
+        <a class="btn btn-sm btn-secondary" href="{{ url_for('main.client_edit', client_id=client.id) }}">Edit</a>
+        <a class="btn btn-sm btn-danger" href="{{ url_for('main.client_delete', client_id=client.id) }}">Delete</a>
+      </div>
+    </div>
+  </div>
+{% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/cloudflare.html
+++ b/app/templates/cloudflare.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Cloudflare Tunnels</h2>
+<form method="post">
+  <input type="hidden" name="save_all" value="1">
+  <div class="row">
+    {% for label, cfg in config.items() %}
+    <div class="col-md-6">
+      <h4 class="mt-3">{{ label|capitalize }} tunnel</h4>
+      <div class="mb-3">
+        <label class="form-label">Hostname</label>
+        <input class="form-control" name="{{ label }}_hostname" value="{{ cfg.hostname }}">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Local Port</label>
+        <input class="form-control" name="{{ label }}_port" value="{{ cfg.port }}">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Token (optional)</label>
+        <input class="form-control" name="{{ label }}_token" value="{{ cfg.token }}">
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+<div class="row mt-3">
+  {% for label, cfg in config.items() %}
+  <div class="col-md-6 mb-3">
+    <h5>{{ label|capitalize }} control</h5>
+    <form method="post" class="d-inline">
+      <input type="hidden" name="label" value="{{ label }}">
+      <input type="hidden" name="start" value="1">
+      <button class="btn btn-success" {% if cfg.running %}disabled{% endif %}>Start</button>
+    </form>
+    <form method="post" class="d-inline ms-2">
+      <input type="hidden" name="label" value="{{ label }}">
+      <input type="hidden" name="stop" value="1">
+      <button class="btn btn-danger" {% if not cfg.running %}disabled{% endif %}>Stop</button>
+    </form>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2>Dashboard</h2>
+  <div>
+    <a class="btn btn-secondary me-2" href="{{ url_for('main.clients_list') }}">Manage Clients</a>
+    <a class="btn btn-secondary" href="{{ url_for('main.organizations') }}">Organizations</a>
+  </div>
+</div>
+<div class="card mb-4">
+  <div class="card-body">
+    <canvas id="statusChart" height="150"></canvas>
+  </div>
+</div>
+<div class="card mb-4">
+  <div class="card-body">
+    <canvas id="systemChart" height="120"></canvas>
+  </div>
+</div>
+<h5>Clients</h5>
+<ul class="list-group">
+  {% for client in clients %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ client.name }} - CPU {{ client.cpu or 'n/a' }}% MEM {{ client.memory or 'n/a' }}%</span>
+    <span class="badge bg-secondary">{{ client.status or 'unknown' }}</span>
+  </li>
+  {% endfor %}
+</ul>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const ctx = document.getElementById('statusChart').getContext('2d');
+  const data = {
+    labels: ['Healthy','Attention','Critical','Offline'],
+    datasets: [{
+      data: [{{ counts.healthy }}, {{ counts.attention }}, {{ counts.critical }}, {{ counts.offline }}],
+      backgroundColor: ['#28a745','#ffc107','#dc3545','#6c757d']
+    }]
+  };
+  new Chart(ctx, {type: 'doughnut', data: data});
+
+  const sysCtx = document.getElementById('systemChart').getContext('2d');
+  const sysData = {
+    labels: ['CPU %','Memory %'],
+    datasets: [{
+      label: 'Usage',
+      data: [{{ sys_stats.cpu }}, {{ sys_stats.memory }}],
+      backgroundColor: ['#007bff','#17a2b8']
+    }]
+  };
+  new Chart(sysCtx, {type: 'bar', data: sysData, options:{scales:{y:{beginAtZero:true,max:100}}}});
+</script>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <div class="card p-4 shadow-sm">
+      <h3 class="mb-3 text-center">Login</h3>
+      <form method="post">
+        <div class="mb-3">
+          <input class="form-control" type="text" name="username" placeholder="Username" required>
+        </div>
+        <div class="mb-3">
+          <input class="form-control" type="password" name="password" placeholder="Password" required>
+        </div>
+        <button class="btn btn-primary w-100" type="submit">Login</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/org_edit.html
+++ b/app/templates/org_edit.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Organization</h2>
+<form method="post" style="max-width:400px;">
+  <div class="mb-3">
+    <input name="name" class="form-control" value="{{ org.name }}" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/organizations.html
+++ b/app/templates/organizations.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Organizations</h2>
+<form method="post" class="mb-3" style="max-width:400px;">
+  <div class="input-group">
+    <input name="name" class="form-control" placeholder="New organization" required>
+    <button class="btn btn-primary" type="submit">Add</button>
+  </div>
+</form>
+<ul class="list-group">
+  {% for org in orgs %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ org.name }}</span>
+    <span>
+      <a href="{{ url_for('main.org_edit', org_id=org.id) }}" class="btn btn-sm btn-secondary">Edit</a>
+      <a href="{{ url_for('main.org_delete', org_id=org.id) }}" class="btn btn-sm btn-danger">Delete</a>
+    </span>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Update Credentials</h2>
+<form method="post" style="max-width:400px;">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username" value="{{ current_user.username }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">New Password</label>
+    <input class="form-control" type="password" name="password" placeholder="Leave blank to keep current">
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/wireguard.html
+++ b/app/templates/wireguard.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>WireGuard</h2>
+<h5>Server</h5>
+<table class="table table-sm mb-4">
+  <tr><th>Address</th><td>{{ interface['Address'] }}</td></tr>
+  <tr><th>ListenPort</th><td>{{ interface['ListenPort'] }}</td></tr>
+</table>
+<h5>Peers</h5>
+<table class="table">
+  <thead><tr><th>Organization</th><th>Client</th><th>Public Key</th><th>Allowed IPs</th><th></th></tr></thead>
+  <tbody>
+  {% for peer in peers %}
+  <tr>
+    <td>{{ peer.get('org','') }}</td>
+    <td>{{ peer.get('client','') }}</td>
+    <td style="word-break:break-all;">{{ peer['PublicKey'] }}</td>
+    <td>{{ peer['AllowedIPs'] }}</td>
+    <td>
+      <form method="post" style="display:inline;">
+        <input type="hidden" name="remove" value="{{ peer['PublicKey'] }}">
+        <button class="btn btn-sm btn-danger" type="submit">Remove</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,513 @@
+import os
+import secrets
+import configparser
+import subprocess
+import psutil
+import signal
+from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, current_app
+from flask_login import login_user, login_required, logout_user, current_user
+from .models import Client, User, Organization
+from . import db
+from werkzeug.security import generate_password_hash, check_password_hash
+
+main_bp = Blueprint('main', __name__)
+
+
+def _append_peer(public_key, allowed_ip):
+    wg_conf = current_app.config.get('WG_CONFIG', '/etc/wireguard/wg0.conf')
+    peer_block = f"\n[Peer]\nPublicKey = {public_key}\nAllowedIPs = {allowed_ip}\n"
+    try:
+        existing = ''
+        if os.path.exists(wg_conf):
+            with open(wg_conf) as f:
+                existing = f.read()
+        if allowed_ip not in existing:
+            with open(wg_conf, 'a') as f:
+                f.write(peer_block)
+            subprocess.run(['sudo', 'systemctl', 'restart', 'wg-quick@wg0'], check=False)
+    except Exception:
+        pass
+
+def _remove_peer(public_key):
+    wg_conf = current_app.config.get('WG_CONFIG', '/etc/wireguard/wg0.conf')
+    try:
+        iface, peers = _parse_wg_config(wg_conf)
+        new_peers = [p for p in peers if p.get('PublicKey') != public_key]
+        if len(new_peers) != len(peers):
+            with open(wg_conf, 'w') as f:
+                f.write('[Interface]\n')
+                for k, v in iface.items():
+                    f.write(f'{k} = {v}\n')
+                for p in new_peers:
+                    f.write('\n[Peer]\n')
+                    for k, v in p.items():
+                        f.write(f'{k} = {v}\n')
+            subprocess.run(['sudo', 'systemctl', 'restart', 'wg-quick@wg0'], check=False)
+    except Exception:
+        pass
+
+def _parse_wg_config(path):
+    interface = {}
+    peers = []
+    current = None
+    if not os.path.exists(path):
+        return interface, peers
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line == '[Interface]':
+                current = interface
+            elif line == '[Peer]':
+                current = {}
+                peers.append(current)
+            elif '=' in line and current is not None:
+                k, v = line.split('=', 1)
+                current[k.strip()] = v.strip()
+    return interface, peers
+
+
+def _tunnel_pid_file(label):
+    return os.path.join(current_app.config['BASEDIR'], f'cloudflared_{label}.pid')
+
+
+def _tunnel_running(label):
+    pid_file = _tunnel_pid_file(label)
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file) as f:
+                pid = int(f.read().strip())
+            os.kill(pid, 0)
+            return True
+        except Exception:
+            os.remove(pid_file)
+    return False
+
+
+def _start_tunnel(label):
+    if _tunnel_running(label):
+        return
+    script = os.path.join(current_app.config['BASEDIR'], 'start_tunnel.sh')
+    p = subprocess.Popen(['bash', script, label])
+    with open(_tunnel_pid_file(label), 'w') as f:
+        f.write(str(p.pid))
+
+
+def _stop_tunnel(label):
+    pid_file = _tunnel_pid_file(label)
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file) as f:
+                pid = int(f.read().strip())
+            os.kill(pid, signal.SIGTERM)
+        except Exception:
+            pass
+        os.remove(pid_file)
+
+@main_bp.route('/')
+def index():
+    if current_user.is_authenticated:
+        return redirect(url_for('main.dashboard'))
+    return redirect(url_for('main.login', next=url_for('main.dashboard')))
+
+@main_bp.route('/dashboard')
+@login_required
+def dashboard():
+    clients = Client.query.all()
+    orgs = Organization.query.all()
+    counts = {
+        'healthy': Client.query.filter_by(status='online').count(),
+        'attention': Client.query.filter_by(status='warning').count(),
+        'critical': Client.query.filter_by(status='critical').count(),
+        'offline': Client.query.filter_by(status='offline').count(),
+    }
+    sys_stats = {
+        'cpu': psutil.cpu_percent(interval=None),
+        'memory': psutil.virtual_memory().percent,
+    }
+    return render_template('dashboard.html', clients=clients, orgs=orgs, counts=counts, sys_stats=sys_stats)
+
+@main_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            next_page = request.args.get('next') or url_for('main.dashboard')
+            return redirect(next_page)
+        flash('Invalid username or password')
+    return render_template('login.html')
+
+@main_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('main.login'))
+
+@main_bp.route('/clients')
+@login_required
+def clients_list():
+    q = request.args.get('q', '')
+    org_id = request.args.get('org')
+    query = Client.query
+    if org_id:
+        query = query.filter_by(organization_id=org_id)
+    if q:
+        query = query.filter(Client.name.contains(q))
+    clients = query.all()
+    orgs = Organization.query.all()
+    return render_template('clients.html', clients=clients, q=q, orgs=orgs, org_id=org_id)
+
+@main_bp.route('/clients/export')
+@login_required
+def export_clients():
+    import json
+    data = []
+    for org in Organization.query.all():
+        org_data = {
+            'id': org.id,
+            'name': org.name,
+            'api_key': org.api_key,
+            'clients': []
+        }
+        for c in org.clients:
+            org_data['clients'].append({
+                'id': c.id,
+                'name': c.name,
+                'location': c.location,
+                'status': c.status,
+                'ip_address': c.ip_address
+            })
+        data.append(org_data)
+    resp = current_app.response_class(
+        json.dumps(data, indent=2),
+        mimetype='application/json'
+    )
+    resp.headers['Content-Disposition'] = 'attachment; filename=clients.json'
+    return resp
+
+@main_bp.route('/backup', methods=['GET', 'POST'])
+@login_required
+def backup():
+    db_path = current_app.config['DB_PATH']
+    if request.method == 'POST':
+        file = request.files.get('db')
+        if file:
+            file.save(db_path)
+            flash('Database imported')
+            return redirect(url_for('main.backup'))
+    if request.args.get('download'):
+        return send_file(db_path, as_attachment=True)
+    return render_template('backup.html')
+
+@main_bp.route('/client/add', methods=['GET', 'POST'])
+@login_required
+def client_add():
+    orgs = Organization.query.all()
+    if request.method == 'POST':
+        name = request.form['name']
+        org_id = request.form.get('organization_id')
+        client = Client(name=name, organization_id=org_id)
+        db.session.add(client)
+        db.session.commit()
+        flash('Client added')
+        return redirect(url_for('main.clients_list'))
+    return render_template('client_add.html', orgs=orgs)
+
+@main_bp.route('/client/<int:client_id>/edit', methods=['GET', 'POST'])
+@login_required
+def client_edit(client_id):
+    client = Client.query.get_or_404(client_id)
+    orgs = Organization.query.all()
+    if request.method == 'POST':
+        client.name = request.form['name']
+        client.location = request.form.get('location')
+        client.organization_id = request.form.get('organization_id')
+        db.session.commit()
+        flash('Client updated')
+        return redirect(url_for('main.clients_list'))
+    return render_template('client_edit.html', client=client, orgs=orgs)
+
+@main_bp.route('/client/<int:client_id>/delete')
+@login_required
+def client_delete(client_id):
+    client = Client.query.get_or_404(client_id)
+    if client.wg_public_key:
+        _remove_peer(client.wg_public_key)
+    db.session.delete(client)
+    db.session.commit()
+    flash('Client deleted')
+    return redirect(url_for('main.clients_list'))
+
+@main_bp.route('/client/<int:client_id>/action/<cmd>')
+@login_required
+def client_action(client_id, cmd):
+    import requests
+    client = Client.query.get_or_404(client_id)
+    if client.ip_address:
+        ip = client.ip_address.split('/')[0]
+        url = f'http://{ip}:5001/action'
+        try:
+            requests.post(url, json={'cmd': cmd, 'api_key': client.organization.api_key}, timeout=5)
+            flash(f'{cmd.capitalize()} command sent')
+        except Exception as exc:
+            flash(f'Failed: {exc}')
+    else:
+        flash('Client heeft geen IP-adres')
+    return redirect(url_for('main.client_manage', client_id=client_id))
+
+@main_bp.route('/client/<int:client_id>')
+@login_required
+def client_detail(client_id):
+    client = Client.query.get_or_404(client_id)
+    return render_template('client.html', client=client)
+
+@main_bp.route('/client/<int:client_id>/manage', methods=['GET', 'POST'])
+@login_required
+def client_manage(client_id):
+    client = Client.query.get_or_404(client_id)
+    output = None
+    if request.method == 'POST':
+        cmd = request.form.get('cmd')
+        if cmd and client.ip_address:
+            import requests
+            ip = client.ip_address.split('/')[0]
+            url = f'http://{ip}:5001/shell'
+            try:
+                resp = requests.post(url, json={'cmd': cmd, 'api_key': client.organization.api_key}, timeout=10)
+                if resp.status_code == 200:
+                    output = resp.text
+                else:
+                    output = f'Error {resp.status_code}'
+            except Exception as exc:
+                output = f'Failed: {exc}'
+        elif cmd:
+            output = 'Geen IP-adres voor client'
+    return render_template('client_manage.html', client=client, output=output)
+
+@main_bp.route('/organizations', methods=['GET', 'POST'])
+@login_required
+def organizations():
+    if request.method == 'POST':
+        name = request.form['name']
+        org = Organization(name=name)
+        db.session.add(org)
+        db.session.commit()
+        return redirect(url_for('main.organizations'))
+    orgs = Organization.query.all()
+    return render_template('organizations.html', orgs=orgs)
+
+@main_bp.route('/organization/<int:org_id>/delete')
+@login_required
+def org_delete(org_id):
+    org = Organization.query.get_or_404(org_id)
+    for c in org.clients:
+        if c.wg_public_key:
+            _remove_peer(c.wg_public_key)
+    db.session.delete(org)
+    db.session.commit()
+    return redirect(url_for('main.organizations'))
+
+@main_bp.route('/organization/<int:org_id>/edit', methods=['GET', 'POST'])
+@login_required
+def org_edit(org_id):
+    org = Organization.query.get_or_404(org_id)
+    if request.method == 'POST':
+        org.name = request.form['name']
+        db.session.commit()
+        return redirect(url_for('main.organizations'))
+    return render_template('org_edit.html', org=org)
+
+@main_bp.route('/plugin/<int:client_id>')
+@login_required
+def download_plugin(client_id):
+    from io import BytesIO
+    import zipfile
+
+    client = Client.query.get_or_404(client_id)
+    org = client.organization
+    if not org.api_key:
+        org.api_key = secrets.token_hex(16)
+        db.session.commit()
+    if not client.wg_private_key:
+        import subprocess
+        priv = subprocess.check_output(['wg', 'genkey']).decode().strip()
+        pub = subprocess.check_output(['bash', '-c', f'echo {priv} | wg pubkey']).decode().strip()
+        client.wg_private_key = priv
+        client.wg_public_key = pub
+        client.ip_address = f'10.0.0.{client.id + 10}/32'
+        db.session.commit()
+        _append_peer(client.wg_public_key, client.ip_address)
+
+    mem = BytesIO()
+    with zipfile.ZipFile(mem, 'w') as zf:
+        for root, dirs, files in os.walk('ha_plugin'):
+            for fname in files:
+                if fname == 'client.conf' or fname == 'config.ini':
+                    continue
+                path = os.path.join(root, fname)
+                arc = os.path.relpath(path, 'ha_plugin')
+                zf.write(path, arc)
+
+        import io, subprocess
+        server_pub = ''
+        pub_path = '/etc/wireguard/server_publickey'
+        if os.path.exists(pub_path):
+            with open(pub_path) as f:
+                server_pub = f.read().strip()
+        else:
+            priv_path = '/etc/wireguard/server_privatekey'
+            if os.path.exists(priv_path):
+                with open(priv_path) as f:
+                    priv = f.read().strip()
+                server_pub = subprocess.check_output(['bash', '-c', f'echo {priv} | wg pubkey']).decode().strip()
+
+        client_conf = f"""[Interface]
+PrivateKey = {client.wg_private_key}
+Address = {client.ip_address}
+
+[Peer]
+PublicKey = {server_pub}
+Endpoint = vpn-ha-management.jayjaysrv.com:51820
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+"""
+        zf.writestr('client.conf', client_conf)
+
+        cfg = configparser.ConfigParser()
+        cfg['portal'] = {
+            'server': 'http://ha-management.jayjaysrv.com',
+            'org_id': str(org.id),
+            'client_id': str(client.id),
+            'api_key': org.api_key,
+            'interval': '600'
+        }
+        buf = io.StringIO()
+        cfg.write(buf)
+        zf.writestr('config.ini', buf.getvalue())
+
+    mem.seek(0)
+    import re
+    slug = re.sub(r'[^A-Za-z0-9]+', '_', client.name).strip('_') or f'client_{client_id}'
+    return send_file(
+        mem,
+        mimetype='application/zip',
+        as_attachment=True,
+        download_name=f'HA_Plugin_{slug}.zip'
+    )
+
+@main_bp.route('/api/heartbeat', methods=['POST'])
+def heartbeat():
+    data = request.get_json() or {}
+    client_id = data.get('client_id')
+    api_key = data.get('api_key')
+    if not client_id or not api_key:
+        return '', 400
+    client = Client.query.get(client_id)
+    if not client or client.organization.api_key != api_key:
+        return '', 403
+    client.status = data.get('status', 'online')
+    hostname = data.get('hostname')
+    if hostname:
+        client.name = hostname
+    client.cpu = data.get('cpu')
+    client.memory = data.get('memory')
+    db.session.commit()
+    return 'ok'
+
+@main_bp.route('/profile', methods=['GET', 'POST'])
+@login_required
+def profile():
+    user = current_user
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form.get('password')
+        user.username = username
+        if password:
+            user.password = generate_password_hash(password)
+        db.session.commit()
+        flash('Credentials updated')
+        return redirect(url_for('main.profile'))
+    return render_template('profile.html')
+
+@main_bp.route('/wireguard', methods=['GET', 'POST'])
+@login_required
+def wireguard():
+    cfg_path = current_app.config.get('WG_CONFIG', '/etc/wireguard/wg0.conf')
+    if request.method == 'POST':
+        if 'remove' in request.form:
+            key = request.form['remove']
+            iface, peers = _parse_wg_config(cfg_path)
+            peers = [p for p in peers if p.get('PublicKey') != key]
+            with open(cfg_path, 'w') as f:
+                f.write('[Interface]\n')
+                for k, v in iface.items():
+                    f.write(f'{k} = {v}\n')
+                for p in peers:
+                    f.write('\n[Peer]\n')
+                    for k, v in p.items():
+                        f.write(f'{k} = {v}\n')
+            subprocess.run(['sudo', 'systemctl', 'restart', 'wg-quick@wg0'], check=False)
+            return redirect(url_for('main.wireguard'))
+    iface, peers = _parse_wg_config(cfg_path)
+    client_map = {c.wg_public_key: c for c in Client.query.all()}
+    for p in peers:
+        c = client_map.get(p.get('PublicKey'))
+        if c:
+            p['client'] = c.name
+            p['org'] = c.organization.name
+    return render_template('wireguard.html', interface=iface, peers=peers)
+
+@main_bp.route('/cloudflare', methods=['GET', 'POST'])
+@login_required
+def cloudflare():
+    cfg_path = current_app.config.get('CF_CONFIG', 'cloudflare.ini')
+    cfg = configparser.ConfigParser()
+    if os.path.exists(cfg_path):
+        cfg.read(cfg_path)
+    labels = [('interface', 'ha-management.jayjaysrv.com'),
+              ('vpn', 'vpn-ha-management.jayjaysrv.com')]
+    if request.method == 'POST':
+        label = request.form.get('label')
+        if 'start' in request.form:
+            _start_tunnel(label)
+            flash(f'{label.capitalize()} tunnel gestart')
+            return redirect(url_for('main.cloudflare'))
+        if 'stop' in request.form:
+            _stop_tunnel(label)
+            flash(f'{label.capitalize()} tunnel gestopt')
+            return redirect(url_for('main.cloudflare'))
+
+        # save both tunnel configs at once
+        for lbl, default_host in labels:
+            host = request.form.get(f'{lbl}_hostname') or default_host
+            port = request.form.get(f'{lbl}_port') or '5000'
+            token = request.form.get(f'{lbl}_token', '')
+            if lbl not in cfg:
+                cfg[lbl] = {}
+            cfg[lbl]['hostname'] = host
+            cfg[lbl]['port'] = port
+            cfg[lbl]['token'] = token
+        with open(cfg_path, 'w') as f:
+            cfg.write(f)
+        flash('Configuratie opgeslagen')
+        return redirect(url_for('main.cloudflare'))
+    data = {}
+    for label, default_host in labels:
+        data[label] = {
+            'hostname': cfg.get(label, 'hostname', fallback=default_host),
+            'port': cfg.get(label, 'port', fallback='5000'),
+            'token': cfg.get(label, 'token', fallback=''),
+            'running': _tunnel_running(label),
+        }
+    return render_template('cloudflare.html', config=data)
+
+@main_bp.route('/init')
+def init_db():
+    db.create_all()
+    if not User.query.filter_by(username='admin').first():
+        admin = User(username='admin', password=generate_password_hash('admin'))
+        db.session.add(admin)
+        db.session.commit()
+    return 'Initialized.'

--- a/ha_plugin/README.md
+++ b/ha_plugin/README.md
@@ -1,0 +1,7 @@
+This Home Assistant custom component connects your instance to the management portal using WireGuard and periodic heartbeats.
+
+1. Copy the `custom_components/ha_management` folder into your Home Assistant `config/custom_components` directory.
+2. Edit `config.ini` with the organization and client identifiers plus VPN details if needed.
+3. Run `./install.sh` on the Home Assistant host to install Python requirements, set up WireGuard and start the heartbeat service.
+
+The heartbeat service also exposes an HTTP API on port 5001 that accepts `reboot`, `shutdown`, `update` and `shell` commands. This allows the management portal to perform remote updates and execute shell commands when needed.

--- a/ha_plugin/client.conf
+++ b/ha_plugin/client.conf
@@ -1,0 +1,9 @@
+[Interface]
+PrivateKey = <client-private-key>
+Address = 10.0.0.2/32
+
+[Peer]
+PublicKey = <server-public-key>
+Endpoint = vpn-ha-management.jayjaysrv.com:51820
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25

--- a/ha_plugin/client.py
+++ b/ha_plugin/client.py
@@ -1,0 +1,53 @@
+import os
+import requests
+import socket
+import time
+import configparser
+import psutil
+import subprocess
+from flask import Flask, request
+import threading
+
+cfg = configparser.ConfigParser()
+cfg.read(os.path.join(os.path.dirname(__file__), 'config.ini'))
+portal = cfg['portal']
+
+SERVER = portal.get('server', 'http://ha-management.jayjaysrv.com')
+ORG_ID = portal.get('org_id', '')
+CLIENT_ID = portal.get('client_id', '')
+API_KEY = portal.get('api_key', '')
+INTERVAL = int(portal.get('interval', '600'))
+
+app = Flask(__name__)
+
+@app.route('/action', methods=['POST'])
+def action():
+    if request.json.get('api_key') != API_KEY:
+        return 'unauthorized', 403
+    cmd = request.json.get('cmd')
+    if cmd == 'reboot':
+        subprocess.Popen(['sudo', 'reboot'])
+    elif cmd == 'shutdown':
+        subprocess.Popen(['sudo', 'shutdown', '-h', 'now'])
+    return 'ok'
+
+def run_server():
+    app.run(host='0.0.0.0', port=5001)
+
+threading.Thread(target=run_server, daemon=True).start()
+
+while True:
+    try:
+        data = {
+            'hostname': socket.gethostname(),
+            'status': 'online',
+            'org_id': ORG_ID,
+            'client_id': CLIENT_ID,
+            'api_key': API_KEY,
+            'cpu': psutil.cpu_percent(),
+            'memory': psutil.virtual_memory().percent,
+        }
+        requests.post(f"{SERVER}/api/heartbeat", json=data, timeout=5)
+    except Exception:
+        pass
+    time.sleep(INTERVAL)

--- a/ha_plugin/config.ini
+++ b/ha_plugin/config.ini
@@ -1,0 +1,6 @@
+[portal]
+server = http://ha-management.jayjaysrv.com
+org_id =
+client_id =
+api_key =
+interval = 600

--- a/ha_plugin/config.ini.template
+++ b/ha_plugin/config.ini.template
@@ -1,0 +1,6 @@
+[portal]
+server = http://ha-management.jayjaysrv.com
+org_id =
+client_id =
+api_key =
+interval = 600

--- a/ha_plugin/custom_components/ha_management/__init__.py
+++ b/ha_plugin/custom_components/ha_management/__init__.py
@@ -1,0 +1,52 @@
+import logging
+import socket
+from datetime import timedelta
+import requests
+import configparser
+import os
+
+DOMAIN = "ha_management"
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    cfg = configparser.ConfigParser()
+    path = os.path.join(os.path.dirname(__file__), '..', '..', 'config.ini')
+    path = os.path.abspath(path)
+    if os.path.exists(path):
+        cfg.read(path)
+        portal = cfg['portal']
+    else:
+        portal = {
+            'server': os.environ.get('SERVER', 'http://ha-management.jayjaysrv.com'),
+            'org_id': os.environ.get('ORG_ID', ''),
+            'client_id': os.environ.get('CLIENT_ID', ''),
+            'api_key': os.environ.get('API_KEY', ''),
+            'interval': os.environ.get('INTERVAL', '600'),
+        }
+
+    server = portal.get('server')
+    org_id = portal.get('org_id')
+    client_id = portal.get('client_id')
+    api_key = portal.get('api_key')
+    interval = int(portal.get('interval', '600'))
+
+    if not org_id:
+        _LOGGER.error("Organization id missing")
+        return False
+
+    def send_heartbeat(event_time):
+        data = {
+            'hostname': socket.gethostname(),
+            'status': 'online',
+            'org_id': org_id,
+            'client_id': client_id,
+            'api_key': api_key,
+        }
+        try:
+            requests.post(f"{server}/api/heartbeat", json=data, timeout=5)
+        except Exception as exc:
+            _LOGGER.warning("Heartbeat failed: %s", exc)
+
+    hass.helpers.event.track_time_interval(send_heartbeat, timedelta(seconds=interval))
+    return True

--- a/ha_plugin/custom_components/ha_management/heartbeat.py
+++ b/ha_plugin/custom_components/ha_management/heartbeat.py
@@ -1,0 +1,69 @@
+import socket
+import time
+import requests
+import configparser
+import os
+import psutil
+import subprocess
+from flask import Flask, request
+import threading
+
+CONFIG = os.path.join(os.path.dirname(__file__), '..', '..', 'config.ini')
+
+cfg = configparser.ConfigParser()
+cfg.read(CONFIG)
+portal = cfg['portal']
+SERVER = portal.get('server', 'http://ha-management.jayjaysrv.com')
+ORG_ID = portal.get('org_id', '')
+CLIENT_ID = portal.get('client_id', '')
+API_KEY = portal.get('api_key', '')
+INTERVAL = int(portal.get('interval', '600'))
+
+app = Flask(__name__)
+
+@app.route('/action', methods=['POST'])
+def action():
+    if request.json.get('api_key') != API_KEY:
+        return 'unauthorized', 403
+    cmd = request.json.get('cmd')
+    if cmd == 'reboot':
+        subprocess.Popen(['sudo', 'reboot'])
+    elif cmd == 'shutdown':
+        subprocess.Popen(['sudo', 'shutdown', '-h', 'now'])
+    elif cmd == 'update':
+        subprocess.Popen(['bash', os.path.join(os.path.dirname(__file__), '..', '..', 'install.sh')])
+    return 'ok'
+
+@app.route('/shell', methods=['POST'])
+def shell():
+    if request.json.get('api_key') != API_KEY:
+        return 'unauthorized', 403
+    command = request.json.get('cmd')
+    if not command:
+        return 'no command', 400
+    try:
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT, timeout=10).decode()
+    except subprocess.CalledProcessError as exc:
+        output = exc.output.decode()
+    return output
+
+def run_server():
+    app.run(host='0.0.0.0', port=5001)
+
+threading.Thread(target=run_server, daemon=True).start()
+
+while True:
+    payload = {
+        'hostname': socket.gethostname(),
+        'status': 'online',
+        'org_id': ORG_ID,
+        'client_id': CLIENT_ID,
+        'api_key': API_KEY,
+        'cpu': psutil.cpu_percent(),
+        'memory': psutil.virtual_memory().percent,
+    }
+    try:
+        requests.post(f"{SERVER}/api/heartbeat", json=payload, timeout=5)
+    except Exception:
+        pass
+    time.sleep(INTERVAL)

--- a/ha_plugin/custom_components/ha_management/manifest.json
+++ b/ha_plugin/custom_components/ha_management/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "ha_management",
+  "name": "HA Management",
+  "documentation": "https://example.com",
+  "version": "0.1",
+  "requirements": ["requests"],
+  "codeowners": []
+}

--- a/ha_plugin/install.sh
+++ b/ha_plugin/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if ! command -v wg >/dev/null; then
+    apt-get update
+    apt-get install -y wireguard
+fi
+
+mkdir -p /etc/wireguard
+cp client.conf /etc/wireguard/wg0.conf
+wg-quick up wg0
+
+cp -r custom_components/ha_management "$HOME/.homeassistant/custom_components/"
+cp config.ini /etc/ha_plugin.conf
+pip3 install requests flask psutil
+
+nohup python3 custom_components/ha_management/heartbeat.py &>/var/log/ha_plugin.log &

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+
+# always run relative to the script location so it works from any path
+cd "$(dirname "$0")"
+
+wait_for_dpkg() {
+    # wait if another apt or dpkg process is running
+    while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+        echo "Waiting for package manager lock..."
+        sleep 5
+    done
+}
+
+if [ "$1" = "cleaninstall" ] || [ "$1" = "--cleaninstall" ]; then
+    echo "Performing clean installation..."
+    sudo systemctl stop ha-management.service 2>/dev/null || true
+    pkill -f "python.*run.py" 2>/dev/null || true
+    sudo systemctl stop wg-quick@wg0 2>/dev/null || true
+    sudo dpkg -r cloudflared 2>/dev/null || true
+    sudo rm -f /etc/wireguard/wg0.conf /etc/wireguard/server_privatekey /etc/wireguard/server_publickey
+    sudo rm -f /etc/wireguard/peers/*.conf 2>/dev/null || true
+    sudo rm -rf /etc/wireguard/*peer* 2>/dev/null || true
+    rm -rf venv management.db cloudflare.ini
+fi
+
+# Basic Ubuntu install script for HA-Management
+
+# update package list and install system dependencies
+wait_for_dpkg
+sudo apt-get update
+wait_for_dpkg
+sudo apt-get install -y python3 python3-venv python3-pip sqlite3 wireguard
+
+# install cloudflared for Cloudflare tunnels if missing
+if ! command -v cloudflared >/dev/null; then
+    wget -qO cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+    wait_for_dpkg
+    sudo dpkg -i cloudflared.deb
+    rm cloudflared.deb
+fi
+
+# create default WireGuard server if none exists
+if [ ! -f /etc/wireguard/wg0.conf ]; then
+    sudo mkdir -p /etc/wireguard
+    sudo chmod 700 /etc/wireguard
+    PRIV=$(wg genkey | sudo tee /etc/wireguard/server_privatekey)
+    PUB=$(echo "$PRIV" | wg pubkey | sudo tee /etc/wireguard/server_publickey)
+    sudo tee /etc/wireguard/wg0.conf >/dev/null <<EOF
+[Interface]
+Address = 10.0.0.1/24
+ListenPort = 51820
+PrivateKey = $PRIV
+EOF
+    sudo systemctl enable wg-quick@wg0
+    sudo systemctl start wg-quick@wg0 || true
+fi
+
+# create python virtual environment if not existing
+if [ ! -d venv ]; then
+    python3 -m venv venv
+fi
+
+# activate venv and install requirements
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# initialize the database and create the admin user
+python run.py init
+
+# create default cloudflare config if none exists
+if [ ! -f cloudflare.ini ]; then
+    cat > cloudflare.ini <<EOF
+[interface]
+hostname = ha-management.jayjaysrv.com
+port = 5000
+token =
+
+[vpn]
+hostname = vpn-ha-management.jayjaysrv.com
+port = 5000
+token =
+EOF
+fi
+
+echo "Setup complete. You can now run the server with: source venv/bin/activate && python run.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask==2.3.2
+SQLAlchemy==2.0.10
+Werkzeug==2.3.6
+Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.3
+requests==2.32.1
+psutil==5.9.8

--- a/run.py
+++ b/run.py
@@ -1,0 +1,15 @@
+from app import create_app
+from app.views import init_db
+import os
+import sys
+
+app = create_app()
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'init':
+        with app.app_context():
+            print(init_db())
+    else:
+        host = os.environ.get('HOST', '0.0.0.0')
+        port = int(os.environ.get('PORT', '5000'))
+        app.run(host=host, port=port, debug=True)

--- a/start_tunnel.sh
+++ b/start_tunnel.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+DIR="$(dirname "$0")"
+CFG="$DIR/cloudflare.ini"
+LABEL=${1:-interface}
+
+get_cfg() {
+  python3 - "$CFG" "$LABEL" "$1" <<'EOF'
+import configparser,sys
+cfg=configparser.ConfigParser(); cfg.read(sys.argv[1])
+print(cfg.get(sys.argv[2], sys.argv[3], fallback=""))
+EOF
+}
+
+HOSTNAME=${HOSTNAME:-$(get_cfg hostname)}
+PORT=${PORT:-$(get_cfg port)}
+TOKEN=${TOKEN:-$(get_cfg token)}
+
+if [ -z "$HOSTNAME" ]; then
+  if [ "$LABEL" = "vpn" ]; then
+    HOSTNAME="vpn-ha-management.jayjaysrv.com"
+  else
+    HOSTNAME="ha-management.jayjaysrv.com"
+  fi
+fi
+PORT=${PORT:-5000}
+if ! command -v cloudflared >/dev/null; then
+  echo "cloudflared not installed. Run install.sh first." >&2
+  exit 1
+fi
+LOG="$DIR/cloudflared_${LABEL}.log"
+
+if [ -n "$TOKEN" ]; then
+  # use a named tunnel created in the Cloudflare dashboard
+  exec cloudflared tunnel --no-autoupdate run --token "$TOKEN" --url http://localhost:$PORT >>"$LOG" 2>&1
+else
+  CMD=(cloudflared tunnel --url http://localhost:$PORT --no-autoupdate)
+  if [ -n "$HOSTNAME" ]; then
+    CMD+=(--hostname "$HOSTNAME")
+  fi
+  exec "${CMD[@]}" >>"$LOG" 2>&1
+fi


### PR DESCRIPTION
## Summary
- add helper to remove WireGuard peers
- delete peer entries when removing a client or organisation
- allow `--cleaninstall` in the installer and delete any leftover peer configs
- add client management page with remote shell and plugin update
- expose shell endpoint in the HA plugin
- prevent errors in client management when IP is missing

## Testing
- `python -m py_compile app/*.py run.py ha_plugin/custom_components/ha_management/heartbeat.py`
- `sudo bash install.sh`
- `source venv/bin/activate && python run.py init`


------
https://chatgpt.com/codex/tasks/task_e_686e6e700e408333865394a1081d8fe2