### PR TITLE
Add Home Assistant token field and management actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ python run.py
 
 The default admin account uses the credentials `admin` / `admin`. Change the
 password after logging in.
+
+## Home Assistant token
+
+Each client entry stores a Home Assistant long lived access token. Create this
+token from your Home Assistant user profile and paste it into the **HA Token**
+field when editing a client. It will be used for API requests sent to
+`http://<client IP>:8123/api/...`.
+
+## WireGuard connectivity
+
+The optional download link for each client now only provides a basic WireGuard
+configuration file. Use this file on the client device to establish a VPN
+connection to the management server. No custom Home Assistant component is
+required anymore.

--- a/app/models.py
+++ b/app/models.py
@@ -6,6 +6,7 @@ class Client(db.Model):
     name = db.Column(db.String(100), nullable=False)
     location = db.Column(db.String(100))
     status = db.Column(db.String(50))
+    ha_token = db.Column(db.String(200))
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/client.html
+++ b/app/templates/client.html
@@ -2,5 +2,9 @@
 {% block content %}
 <h2>{{ client.name }}</h2>
 <p>Status: {{ client.status or 'unknown' }}</p>
-<!-- Placeholder for remote management actions -->
+<p>
+    <a href="{{ url_for('main.client_edit', client_id=client.id) }}">Edit</a> |
+    <a href="{{ url_for('main.client_manage', client_id=client.id) }}">Manage</a> |
+    <a href="{{ url_for('main.download_plugin', client_id=client.id) }}">Download config</a>
+</p>
 {% endblock %}

--- a/app/templates/client_edit.html
+++ b/app/templates/client_edit.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Client</h2>
+<form method="post">
+    <label>Name <input type="text" name="name" value="{{ client.name }}"></label><br>
+    <label>Location <input type="text" name="location" value="{{ client.location }}"></label><br>
+    <label>Status <input type="text" name="status" value="{{ client.status }}"></label><br>
+    <label>HA Token <input type="text" name="ha_token" value="{{ client.ha_token }}"></label><br>
+    <input type="submit" value="Save">
+</form>
+{% endblock %}

--- a/app/templates/client_manage.html
+++ b/app/templates/client_manage.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Manage {{ client.name }}</h2>
+<form method="post" action="{{ url_for('main.client_action', client_id=client.id) }}">
+    <label>API path <input type="text" name="path" placeholder="services/..."/></label><br>
+    <label>JSON payload<br><textarea name="payload" rows="4" cols="50"></textarea></label><br>
+    <input type="submit" value="Send">
+</form>
+{% if output %}
+<pre>{{ output }}</pre>
+{% endif %}
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -1,8 +1,10 @@
-from flask import Blueprint, render_template, request, redirect, url_for
+from flask import Blueprint, render_template, request, redirect, url_for, Response
 from flask_login import login_user, login_required, logout_user, current_user
 from .models import Client, User
 from . import db
 from werkzeug.security import generate_password_hash, check_password_hash
+import json
+import requests
 
 main_bp = Blueprint('main', __name__)
 
@@ -42,6 +44,53 @@ def client_detail(client_id):
     client = Client.query.get_or_404(client_id)
     # placeholder for real management features
     return render_template('client.html', client=client)
+
+@main_bp.route('/client/<int:client_id>/edit', methods=['GET', 'POST'])
+@login_required
+def client_edit(client_id):
+    client = Client.query.get_or_404(client_id)
+    if request.method == 'POST':
+        client.name = request.form['name']
+        client.location = request.form['location']
+        client.status = request.form['status']
+        client.ha_token = request.form.get('ha_token')
+        db.session.commit()
+        return redirect(url_for('main.client_detail', client_id=client.id))
+    return render_template('client_edit.html', client=client)
+
+@main_bp.route('/client/<int:client_id>/manage')
+@login_required
+def client_manage(client_id):
+    client = Client.query.get_or_404(client_id)
+    return render_template('client_manage.html', client=client)
+
+@main_bp.route('/client/<int:client_id>/action', methods=['POST'])
+@login_required
+def client_action(client_id):
+    client = Client.query.get_or_404(client_id)
+    path = request.form['path']
+    payload = request.form.get('payload')
+    url = f"http://{client.location}:8123/api/{path.lstrip('/')}"
+    headers = {"Authorization": f"Bearer {client.ha_token}"}
+    data = None
+    if payload:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            data = payload
+    try:
+        r = requests.post(url, headers=headers, json=data)
+        output = r.text
+    except Exception as e:
+        output = str(e)
+    return render_template('client_manage.html', client=client, output=output)
+
+@main_bp.route('/client/<int:client_id>/download')
+@login_required
+def download_plugin(client_id):
+    client = Client.query.get_or_404(client_id)
+    wg_conf = f"[Interface]\nPrivateKey = <private>\nAddress = 10.0.0.{client.id}/32\n\n[Peer]\nEndpoint = {request.host.split(':')[0]}:51820\nAllowedIPs = 0.0.0.0/0\n"
+    return Response(wg_conf, mimetype='text/plain', headers={'Content-Disposition': f'attachment; filename=client-{client.id}-wg.conf'})
 
 @main_bp.route('/init')
 def init_db():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ SQLAlchemy==2.0.10
 Werkzeug==2.3.6
 Flask-Login==0.6.2
 Flask-SQLAlchemy==3.0.3
+requests==2.31.0


### PR DESCRIPTION
## Summary
- allow storing a Home Assistant long lived token for each client
- include a form to edit client details and token
- add management views that send API requests directly to the client using the stored token
- provide WireGuard-only config download
- document token usage and WireGuard setup
- add `requests` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a0699dbb48333b4ad38c4b5df63a6